### PR TITLE
Revert "canonicalize domain as www.shaggyhf.com"

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,1 +1,0 @@
-https://shaggyhf.com/*  https://www.shaggyhf.com/:splat  301!


### PR DESCRIPTION
Reverts knoxthedog/shaggyhf#13

(This didn't work. This method does not work at the DNS layer - just within the pages of a single Cloudflare Pages site)