### PR TITLE
Rw lead calculator

### DIFF
--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -28,6 +28,7 @@ npx vitest run     # Run tests once (CI mode)
 | `index.html` | Landing page, API key storage, tool navigation | `apiKeyModel()` from `src/api_key_model.js` |
 | `rw_matcher.html` | Ranked War Matchmaker (3-step wizard) | `newRWMatcherModel()` from `src/rw_matcher_model.js` |
 | `rw_payroll.html` | Ranked War Payroll Calculator (3-step wizard) | `payrollModel()` from `src/rw_payroll_model.js` |
+| `rw_lead.html` | Ranked War Lead Calculator (2-step wizard) | `leadModel()` from `src/rw_lead_model.js` |
 
 ## Module Map
 
@@ -39,6 +40,8 @@ src/
 ├── torn_api.js              # Torn.com v2 API client + hit classification
 ├── datetime_model.js        # Alpine component for datetime-local inputs
 ├── wizard_nav.js            # Shared wizard footer (Back/dots/Next)
+├── war_score.js             # Ranked war target decay formulas
+├── rw_lead_model.js         # Lead calculator page Alpine model
 ├── rw_matcher_model.js      # Matcher page Alpine model
 ├── rw_payroll_model.js      # Payroll page Alpine model
 └── style.css                # Tailwind base + custom CSS variables
@@ -50,6 +53,8 @@ src/
 - `target_matcher.js` → `spy_parser.js`
 - `rw_matcher_model.js` → `spy_parser.js`, `target_matcher.js`
 - `rw_payroll_model.js` → `torn_api.js`
+- `rw_lead_model.js` → `torn_api.js`, `war_score.js`, `datetime_model.js`
+- `war_score.js` → (none)
 - `datetime_model.js` → (none)
 - `wizard_nav.js` → (none)
 - `api_key_model.js` → (none)
@@ -86,7 +91,7 @@ Models are registered in the page's `<script type="module">` block, either via `
 
 ### Wizard Pages
 
-Wizard pages use a 3-step pattern with `step`, `prevStep()`, `nextStep()`, and `canProceed()` on the model. The shared wizard footer is mounted via `mountWizardFooter()` from `src/wizard_nav.js` — call it **before** `Alpine.start()`.
+Wizard pages use a step-based pattern with `step`, `prevStep()`, `nextStep()`, and `canProceed()` on the model. The shared wizard footer is mounted via `mountWizardFooter(steps)` from `src/wizard_nav.js` — call it **before** `Alpine.start()`, passing the number of steps explicitly.
 
 `prevStep()` at step 1 navigates back to `./index.html` — this is a shared contract across all wizard models.
 
@@ -129,7 +134,7 @@ Tailwind scans `./src/**/*.{js,html}` and `./*.html` for class names. When writi
        import { mountWizardFooter } from './src/wizard_nav.js'
 
        Alpine.data('myModel', myModel)
-       mountWizardFooter()
+       mountWizardFooter(3)
        Alpine.start()
    </script>
    </body>

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,12 @@
                 Ranked War Payroll Calculator
             </a>
         </li>
+        <li>
+            <a href="rw_lead.html"
+               class="block px-4 py-2 rounded bg-accent text-white hover:bg-accentHover">
+                Ranked War Lead Calculator
+            </a>
+        </li>
     </ul>
 </div>
 

--- a/web/rw_lead.html
+++ b/web/rw_lead.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en" class="bg-background">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ranked War Lead Calculator</title>
+    <link rel="stylesheet" href="./src/style.css" />
+</head>
+<body class="min-h-screen p-6 pb-24 text-textPrimary bg-background"
+      x-data="leadModel()"
+      x-init="init()">
+
+<div class="max-w-4xl mx-auto bg-surface p-6 rounded-xl shadow-md">
+    <h1 class="text-2xl font-bold mb-4">Ranked War Lead Calculator</h1>
+
+    <!-- Step 1: Select War + Configure -->
+    <template x-if="step === 1">
+        <div class="space-y-6">
+
+            <!-- API Key -->
+            <template x-if="!apiKey">
+                <div>
+                    <label class="block mb-2 font-medium">Torn API Key</label>
+                    <input x-model="apiKeyInput" type="text" class="input-compact mb-3" placeholder="Paste your Torn API key here" />
+                    <button @click="saveApiKey" :disabled="!apiKeyInput" class="btn-compact bg-accent text-white hover:bg-accentHover disabled:opacity-50">Save API Key</button>
+                </div>
+            </template>
+
+            <!-- War picker -->
+            <template x-if="apiKey && ongoingWars.length">
+                <div>
+                    <div class="text-sm text-textSecondary">War vs</div>
+                    <div class="text-lg font-semibold" x-text="theirFaction?.name || 'Unknown'"></div>
+                </div>
+            </template>
+
+            <template x-if="apiKey && !isLoading && !ongoingWars.length && !error">
+                <div class="text-sm text-textSecondary">No ongoing ranked wars found.</div>
+            </template>
+
+            <!-- War details -->
+            <template x-if="selectedWar">
+                <div class="space-y-4">
+                    <div class="grid md:grid-cols-2 gap-4">
+                        <div class="p-4 border border-border rounded-lg">
+                            <div class="text-sm text-textSecondary mb-1">Our Score</div>
+                            <div class="text-2xl font-bold" x-text="fmtScore(ourFaction?.score)"></div>
+                            <div class="text-sm text-textSecondary" x-text="ourFaction?.name"></div>
+                        </div>
+                        <div class="p-4 border border-border rounded-lg">
+                            <div class="text-sm text-textSecondary mb-1">Their Score</div>
+                            <div class="text-2xl font-bold" x-text="fmtScore(theirFaction?.score)"></div>
+                            <div class="text-sm text-textSecondary" x-text="theirFaction?.name"></div>
+                        </div>
+                    </div>
+
+                    <div class="grid md:grid-cols-2 gap-4">
+                        <div>
+                            <div class="text-sm text-textSecondary">Current Target</div>
+                            <div class="text-lg font-semibold" x-text="fmtScore(selectedWar.target)"></div>
+                        </div>
+                        <div>
+                            <div class="text-sm text-textSecondary">War Started</div>
+                            <div class="text-lg font-semibold" x-text="warStartFormatted"></div>
+                        </div>
+                    </div>
+
+                    <!-- Deadline input -->
+                    <div>
+                        <label class="block mb-1 font-medium">Deadline (TCT)</label>
+                        <p class="text-sm text-textSecondary mb-2">Default: 12 hours before next Tuesday enrollment</p>
+                        <input type="datetime-local" x-model="deadlineStr" class="input-compact w-full md:w-auto" />
+                    </div>
+                </div>
+            </template>
+
+            <template x-if="isLoading">
+                <div class="text-sm text-textSecondary">
+                    <span class="animate-spin inline-block w-4 h-4 border-2 border-border border-t-transparent rounded-full mr-2"></span>
+                    Fetching ranked wars...
+                </div>
+            </template>
+
+            <template x-if="error">
+                <div class="mt-2 p-3 rounded border border-dangerText bg-dangerBg text-dangerText text-sm" x-text="error"></div>
+            </template>
+        </div>
+    </template>
+
+    <!-- Step 2: Results -->
+    <template x-if="step === 2">
+        <div class="space-y-6">
+            <div class="grid md:grid-cols-2 gap-4">
+                <div class="p-4 border border-border rounded-lg">
+                    <div class="text-sm text-textSecondary mb-1">Your Score</div>
+                    <div class="text-2xl font-bold" x-text="fmtScore(ourFaction?.score)"></div>
+                </div>
+                <div class="p-4 border border-border rounded-lg">
+                    <div class="text-sm text-textSecondary mb-1">Target at Deadline</div>
+                    <div class="text-2xl font-bold" x-text="fmtScore(targetAtDeadline)"></div>
+                </div>
+            </div>
+
+            <!-- Result message -->
+            <template x-if="canCoast">
+                <div class="p-4 rounded border border-successText bg-successBg text-successText">
+                    <div class="font-semibold text-lg mb-1">You can stop hitting.</div>
+                    <div class="text-sm">Your score already exceeds what the target will be at the deadline.</div>
+                    <template x-if="coastTimeFormatted">
+                        <div class="text-sm mt-2">The target will decay to your current score at: <strong x-text="coastTimeFormatted"></strong></div>
+                    </template>
+                </div>
+            </template>
+
+            <template x-if="!canCoast">
+                <div class="p-4 rounded border border-warningText bg-warningBg text-warningText">
+                    <div class="font-semibold text-lg mb-1">You need more points.</div>
+                    <div class="text-sm">
+                        You need <strong x-text="fmtScore(pointsNeeded)"></strong> more points for the target to decay below your score by the deadline.
+                    </div>
+                    <template x-if="coastTimeFormatted">
+                        <div class="text-sm mt-2">If you stop now, the target reaches your score at: <strong x-text="coastTimeFormatted"></strong></div>
+                    </template>
+                    <template x-if="!coastTimeFormatted">
+                        <div class="text-sm mt-2">Your current score is too low for the target to ever decay to it within the war's maximum duration.</div>
+                    </template>
+                </div>
+            </template>
+
+            <!-- Summary table -->
+            <div class="text-sm grid gap-y-1" style="grid-template-columns: max-content auto; column-gap: 1ch;">
+                <div class="text-textSecondary">Original Target:</div>
+                <div class="font-medium" x-text="fmtScore(originalTarget)"></div>
+
+                <div class="text-textSecondary">Current Target:</div>
+                <div class="font-medium" x-text="fmtScore(selectedWar?.target)"></div>
+
+                <div class="text-textSecondary">Target at Deadline:</div>
+                <div class="font-medium" x-text="fmtScore(targetAtDeadline)"></div>
+
+                <div class="text-textSecondary">Our Score:</div>
+                <div class="font-medium" x-text="fmtScore(ourFaction?.score)"></div>
+
+                <div class="text-textSecondary">Their Score:</div>
+                <div class="font-medium" x-text="fmtScore(theirFaction?.score)"></div>
+
+                <div class="text-textSecondary">Points Still Needed:</div>
+                <div class="font-medium" x-text="fmtScore(pointsNeeded)"></div>
+            </div>
+        </div>
+    </template>
+
+</div>
+
+<script type="module">
+    import Alpine from 'alpinejs'
+    import { leadModel } from './src/rw_lead_model.js'
+    import { mountWizardFooter } from './src/wizard_nav.js'
+
+    Alpine.data('leadModel', leadModel)
+    mountWizardFooter(2)
+    Alpine.start()
+</script>
+</body>
+</html>

--- a/web/rw_matcher.html
+++ b/web/rw_matcher.html
@@ -247,7 +247,7 @@
         });
     });
 
-    mountWizardFooter()
+    mountWizardFooter(3)
     window.Alpine = Alpine
     Alpine.start()
 </script>

--- a/web/rw_payroll.html
+++ b/web/rw_payroll.html
@@ -235,7 +235,7 @@
     window.Alpine = Alpine
     Alpine.data('payrollModel', payrollModel)
     Alpine.data('datetimeField', datetimeField)
-    mountWizardFooter()
+    mountWizardFooter(3)
     Alpine.start()
 </script>
 </body>

--- a/web/src/rw_lead_model.js
+++ b/web/src/rw_lead_model.js
@@ -1,0 +1,157 @@
+import { newTornApiClient } from './torn_api.js'
+import { computeOriginalTarget, targetAtTime, scoreNeeded, coastTime, nextEnrollmentDeadline } from './war_score.js'
+import { epochToDatetimeLocal, datetimeLocalToEpoch } from './datetime_model.js'
+
+const FACTION_ID = 49297
+
+const fmtScore = (n) => {
+    const num = Math.round(typeof n === 'number' ? n : 0)
+    return num.toLocaleString()
+}
+
+export function leadModel() {
+    return {
+        apiKey: null,
+        apiKeyInput: '',
+        apiClient: null,
+
+        ongoingWars: [],
+        selectedWarId: '',
+        isLoading: false,
+        error: '',
+
+        step: 1,
+
+        deadlineStr: '',
+
+        get selectedWar() {
+            return this.ongoingWars.find(w => `${w.id}` === `${this.selectedWarId}`) || null
+        },
+
+        get ourFaction() {
+            return this.selectedWar?.factions?.find(f => f.id === FACTION_ID) || null
+        },
+
+        get theirFaction() {
+            return this.selectedWar?.factions?.find(f => f.id !== FACTION_ID) || null
+        },
+
+        get originalTarget() {
+            if (!this.selectedWar) return 0
+            return computeOriginalTarget(
+                this.selectedWar.target,
+                this.selectedWar.start,
+                Date.now() / 1000
+            )
+        },
+
+        get deadlineEpoch() {
+            if (!this.deadlineStr) return null
+            return datetimeLocalToEpoch(this.deadlineStr)
+        },
+
+        get targetAtDeadline() {
+            if (!this.selectedWar || !this.deadlineEpoch) return 0
+            return targetAtTime(this.originalTarget, this.selectedWar.start, this.deadlineEpoch)
+        },
+
+        get pointsNeeded() {
+            if (!this.ourFaction || !this.deadlineEpoch) return 0
+            return scoreNeeded(this.ourFaction.score, this.originalTarget, this.selectedWar.start, this.deadlineEpoch)
+        },
+
+        get canCoast() {
+            return this.ourFaction && this.pointsNeeded === 0
+        },
+
+        get coastTimeEpoch() {
+            if (!this.ourFaction || !this.selectedWar) return null
+            return coastTime(this.ourFaction.score, this.originalTarget, this.selectedWar.start)
+        },
+
+        get coastTimeFormatted() {
+            if (!this.coastTimeEpoch) return null
+            return new Date(this.coastTimeEpoch * 1000).toISOString().replace('T', ' ').replace('Z', '') + ' TCT'
+        },
+
+        get warStartFormatted() {
+            if (!this.selectedWar) return ''
+            return new Date(this.selectedWar.start * 1000).toISOString().replace('T', ' ').replace('Z', '') + ' TCT'
+        },
+
+        fmtScore,
+
+        nextStep() {
+            if (this.step === 1 && this.canProceed()) {
+                this.step = 2
+            }
+        },
+
+        prevStep() {
+            if (this.step === 1) {
+                window.location.href = './index.html'
+            } else {
+                this.step = 1
+            }
+        },
+
+        canProceed() {
+            return !!this.selectedWarId && !!this.deadlineEpoch && !this.isLoading
+        },
+
+        saveApiKey() {
+            if (!this.apiKeyInput) return
+            localStorage.setItem('tornApiKey', this.apiKeyInput)
+            this.apiKey = this.apiKeyInput
+            this.apiKeyInput = ''
+            this.setupApiClient()
+            this.fetchWars()
+        },
+
+        setupApiClient() {
+            this.apiClient = newTornApiClient(this.apiKey, fetch, 'https://api.torn.com/v2')
+        },
+
+        async fetchWars() {
+            this.isLoading = true
+            this.error = ''
+            try {
+                const result = await this.apiClient.fetchRankedWars(FACTION_ID)
+                const wars = Array.isArray(result.rankedwars) ? result.rankedwars : Object.values(result.rankedwars || {})
+                this.ongoingWars = wars
+                    .filter(w => w.winner == null || w.winner === 0)
+                    .map(w => ({
+                        id: w.id,
+                        start: w.start,
+                        end: w.end,
+                        target: w.target,
+                        winner: w.winner,
+                        factions: w.factions,
+                    }))
+                if (this.ongoingWars.length === 1) {
+                    this.selectedWarId = String(this.ongoingWars[0].id)
+                }
+            } catch (err) {
+                console.error(err)
+                this.error = 'Failed to fetch ranked wars.'
+            } finally {
+                this.isLoading = false
+            }
+        },
+
+        onSelectedWarChange(newId) {
+            if (!newId) return
+            const now = Date.now() / 1000
+            this.deadlineStr = epochToDatetimeLocal(nextEnrollmentDeadline(now))
+        },
+
+        init() {
+            this.apiKey = localStorage.getItem('tornApiKey')
+            if (this.apiKey) {
+                this.setupApiClient()
+                this.fetchWars()
+            }
+            this.$watch('selectedWarId', (newId) => this.onSelectedWarChange(newId))
+        },
+    }
+}

--- a/web/src/rw_lead_model.test.js
+++ b/web/src/rw_lead_model.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { leadModel } from './rw_lead_model.js'
+
+describe('leadModel', () => {
+    let m
+
+    beforeEach(() => {
+        localStorage.clear()
+        m = leadModel()
+    })
+
+    describe('war selection', () => {
+        it('selectedWar returns null when no war selected', () => {
+            m.selectedWarId = ''
+            m.ongoingWars = []
+            expect(m.selectedWar).toBeNull()
+        })
+
+        it('selectedWar returns matching war', () => {
+            m.ongoingWars = [
+                { id: 1, start: 1000, target: 5000, factions: [] },
+                { id: 2, start: 2000, target: 8000, factions: [] },
+            ]
+            m.selectedWarId = '2'
+            expect(m.selectedWar.target).toBe(8000)
+        })
+
+        it('ourFaction and theirFaction extract correctly', () => {
+            m.ongoingWars = [{
+                id: 1, start: 1000, target: 5000,
+                factions: [
+                    { id: 49297, name: 'Shaggy', score: 3000 },
+                    { id: 99999, name: 'Enemy', score: 1000 },
+                ]
+            }]
+            m.selectedWarId = '1'
+            expect(m.ourFaction.score).toBe(3000)
+            expect(m.theirFaction.name).toBe('Enemy')
+        })
+    })
+
+    describe('canProceed', () => {
+        it('returns false without war or deadline', () => {
+            expect(m.canProceed()).toBe(false)
+        })
+
+        it('returns true with war, deadline, and not loading', () => {
+            m.selectedWarId = '1'
+            m.deadlineStr = '2026-04-21T00:00'
+            m.isLoading = false
+            expect(m.canProceed()).toBe(true)
+        })
+
+        it('returns false while loading', () => {
+            m.selectedWarId = '1'
+            m.deadlineStr = '2026-04-21T00:00'
+            m.isLoading = true
+            expect(m.canProceed()).toBe(false)
+        })
+    })
+
+    describe('navigation', () => {
+        it('prevStep at step 1 navigates to index.html', () => {
+            m.step = 1
+            const original = window.location.href
+            delete window.location
+            window.location = { href: '' }
+
+            m.prevStep()
+
+            expect(window.location.href).toBe('./index.html')
+            window.location = { href: original }
+        })
+
+        it('prevStep at step 2 goes to step 1', () => {
+            m.step = 2
+            m.prevStep()
+            expect(m.step).toBe(1)
+        })
+
+        it('nextStep advances when canProceed', () => {
+            m.selectedWarId = '1'
+            m.deadlineStr = '2026-04-21T00:00'
+            m.step = 1
+            m.nextStep()
+            expect(m.step).toBe(2)
+        })
+
+        it('nextStep does not advance when cannot proceed', () => {
+            m.selectedWarId = ''
+            m.step = 1
+            m.nextStep()
+            expect(m.step).toBe(1)
+        })
+    })
+
+    describe('score formatting', () => {
+        it('formats numbers with thousands separators', () => {
+            expect(m.fmtScore(1234567)).toBe('1,234,567')
+            expect(m.fmtScore(0)).toBe('0')
+        })
+    })
+
+    describe('auto-selection', () => {
+        it('fetchWars auto-selects when exactly one ongoing war', async () => {
+            m.apiClient = {
+                fetchRankedWars: vi.fn().mockResolvedValue({
+                    rankedwars: [
+                        { id: 42, start: 1000, end: 0, target: 5000, winner: null, factions: [] },
+                        { id: 99, start: 2000, end: 0, target: 8000, winner: 1, factions: [] },
+                    ]
+                })
+            }
+            await m.fetchWars()
+            expect(m.ongoingWars).toHaveLength(1)
+            expect(m.selectedWarId).toBe('42')
+        })
+
+        it('fetchWars does not auto-select when no ongoing wars', async () => {
+            m.apiClient = {
+                fetchRankedWars: vi.fn().mockResolvedValue({
+                    rankedwars: [
+                        { id: 99, start: 2000, end: 0, target: 8000, winner: 1, factions: [] },
+                    ]
+                })
+            }
+            await m.fetchWars()
+            expect(m.ongoingWars).toHaveLength(0)
+            expect(m.selectedWarId).toBe('')
+        })
+    })
+})

--- a/web/src/war_score.js
+++ b/web/src/war_score.js
@@ -1,0 +1,54 @@
+const DECAY_START_HOURS = 24
+const DECAY_RATE_PER_HOUR = 0.01
+const MAX_WAR_HOURS = 123
+
+export function computeOriginalTarget(currentTarget, warStartEpoch, nowEpoch) {
+    const hoursElapsed = (nowEpoch - warStartEpoch) / 3600
+    if (hoursElapsed <= DECAY_START_HOURS) return currentTarget
+    const decayHours = hoursElapsed - DECAY_START_HOURS
+    return currentTarget / (1 - DECAY_RATE_PER_HOUR * decayHours)
+}
+
+export function targetAtTime(originalTarget, warStartEpoch, timeEpoch) {
+    const hoursElapsed = (timeEpoch - warStartEpoch) / 3600
+    if (hoursElapsed <= DECAY_START_HOURS) return originalTarget
+    const decayHours = Math.min(hoursElapsed - DECAY_START_HOURS, MAX_WAR_HOURS - DECAY_START_HOURS)
+    return Math.max(0, originalTarget * (1 - DECAY_RATE_PER_HOUR * decayHours))
+}
+
+export function scoreNeeded(ourScore, originalTarget, warStartEpoch, deadlineEpoch) {
+    const target = targetAtTime(originalTarget, warStartEpoch, deadlineEpoch)
+    return Math.max(0, Math.ceil(target - ourScore))
+}
+
+export function coastTime(ourScore, originalTarget, warStartEpoch) {
+    if (ourScore <= 0 || originalTarget <= 0) return null
+    if (ourScore >= originalTarget) return warStartEpoch
+
+    const decayPerHour = originalTarget * DECAY_RATE_PER_HOUR
+    const decayHoursNeeded = (originalTarget - ourScore) / decayPerHour
+    const totalHours = DECAY_START_HOURS + decayHoursNeeded
+
+    if (totalHours > MAX_WAR_HOURS) return null
+    return warStartEpoch + totalHours * 3600
+}
+
+export function nextEnrollmentDeadline(nowEpoch, hoursBeforeEnrollment = 12) {
+    const enrollmentHourTCT = 12
+    const now = new Date(nowEpoch * 1000)
+    const utcDay = now.getUTCDay()
+    const utcHour = now.getUTCHours()
+
+    // Tuesday = 2. Find days until next Tuesday
+    let daysUntilTuesday = (2 - utcDay + 7) % 7
+    if (daysUntilTuesday === 0 && utcHour >= enrollmentHourTCT) {
+        daysUntilTuesday = 7
+    }
+
+    const nextTuesday = new Date(now)
+    nextTuesday.setUTCDate(now.getUTCDate() + daysUntilTuesday)
+    nextTuesday.setUTCHours(enrollmentHourTCT, 0, 0, 0)
+
+    const enrollmentEpoch = nextTuesday.getTime() / 1000
+    return enrollmentEpoch - hoursBeforeEnrollment * 3600
+}

--- a/web/src/war_score.test.js
+++ b/web/src/war_score.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { computeOriginalTarget, targetAtTime, scoreNeeded, coastTime, nextEnrollmentDeadline } from './war_score.js'
+
+const HOUR = 3600
+
+describe('computeOriginalTarget', () => {
+    const warStart = 1000000
+
+    it('returns currentTarget as-is before 24h', () => {
+        const now = warStart + 12 * HOUR
+        expect(computeOriginalTarget(5000, warStart, now)).toBe(5000)
+    })
+
+    it('returns currentTarget at exactly 24h', () => {
+        const now = warStart + 24 * HOUR
+        expect(computeOriginalTarget(5000, warStart, now)).toBe(5000)
+    })
+
+    it('reverse-computes original target after decay', () => {
+        const now = warStart + 34 * HOUR // 10h of decay = 10% decay
+        // If original was 10000, after 10h decay: 10000 * (1 - 0.1) = 9000
+        expect(computeOriginalTarget(9000, warStart, now)).toBeCloseTo(10000, 5)
+    })
+
+    it('reverse-computes correctly at 50h elapsed (26h decay)', () => {
+        const now = warStart + 50 * HOUR
+        // original 10000, 26h decay: 10000 * (1 - 0.26) = 7400
+        expect(computeOriginalTarget(7400, warStart, now)).toBeCloseTo(10000, 5)
+    })
+})
+
+describe('targetAtTime', () => {
+    const warStart = 1000000
+    const original = 10000
+
+    it('returns original target before 24h', () => {
+        expect(targetAtTime(original, warStart, warStart + 0)).toBe(10000)
+        expect(targetAtTime(original, warStart, warStart + 12 * HOUR)).toBe(10000)
+        expect(targetAtTime(original, warStart, warStart + 24 * HOUR)).toBe(10000)
+    })
+
+    it('decays 1% per hour after 24h', () => {
+        expect(targetAtTime(original, warStart, warStart + 25 * HOUR)).toBeCloseTo(9900, 5)
+        expect(targetAtTime(original, warStart, warStart + 34 * HOUR)).toBeCloseTo(9000, 5)
+        expect(targetAtTime(original, warStart, warStart + 74 * HOUR)).toBeCloseTo(5000, 5)
+    })
+
+    it('floors at minimum (1% of original) at 123h', () => {
+        // 99h of decay = 99%, leaving 1% = 100
+        expect(targetAtTime(original, warStart, warStart + 200 * HOUR)).toBeCloseTo(100, 5)
+    })
+
+    it('reaches 0 at 123h (99h of decay = 99%)', () => {
+        const target = targetAtTime(original, warStart, warStart + 123 * HOUR)
+        expect(target).toBeCloseTo(100, 5)
+    })
+
+    it('does not go below 1% even well past 124h', () => {
+        expect(targetAtTime(original, warStart, warStart + 124 * HOUR)).toBeCloseTo(100, 5)
+    })
+})
+
+describe('scoreNeeded', () => {
+    const warStart = 1000000
+    const original = 10000
+
+    it('returns 0 when score already exceeds target at deadline', () => {
+        const deadline = warStart + 74 * HOUR // target = 5000
+        expect(scoreNeeded(6000, original, warStart, deadline)).toBe(0)
+    })
+
+    it('returns 0 when score equals target at deadline', () => {
+        const deadline = warStart + 74 * HOUR // target = 5000
+        expect(scoreNeeded(5000, original, warStart, deadline)).toBe(0)
+    })
+
+    it('returns correct deficit', () => {
+        const deadline = warStart + 74 * HOUR // target = 5000
+        expect(scoreNeeded(3000, original, warStart, deadline)).toBe(2000)
+    })
+
+    it('rounds up to next integer', () => {
+        const deadline = warStart + 25 * HOUR // target = 9900
+        expect(scoreNeeded(9899.5, original, warStart, deadline)).toBe(1)
+    })
+
+    it('uses full original target before 24h', () => {
+        const deadline = warStart + 12 * HOUR
+        expect(scoreNeeded(8000, original, warStart, deadline)).toBe(2000)
+    })
+})
+
+describe('coastTime', () => {
+    const warStart = 1000000
+    const original = 10000
+
+    it('returns null when score is 0', () => {
+        expect(coastTime(0, original, warStart)).toBeNull()
+    })
+
+    it('returns null when originalTarget is 0', () => {
+        expect(coastTime(5000, 0, warStart)).toBeNull()
+    })
+
+    it('returns warStart when score already meets original target', () => {
+        expect(coastTime(10000, original, warStart)).toBe(warStart)
+        expect(coastTime(15000, original, warStart)).toBe(warStart)
+    })
+
+    it('calculates correct coast time for 50% of target', () => {
+        // Need 50% decay → 50h of decay → 74h total from war start
+        const result = coastTime(5000, original, warStart)
+        expect(result).toBeCloseTo(warStart + 74 * HOUR, 0)
+    })
+
+    it('calculates correct coast time for 90% of target', () => {
+        // Need 10% decay → 10h of decay → 34h total
+        const result = coastTime(9000, original, warStart)
+        expect(result).toBeCloseTo(warStart + 34 * HOUR, 0)
+    })
+
+    it('returns null when score is too low to ever be reached within 123h', () => {
+        // At 123h, target decays by 99% → 100 remaining. Score of 50 is unreachable.
+        expect(coastTime(50, original, warStart)).toBeNull()
+    })
+
+    it('handles score just above minimum reachable', () => {
+        // 99h of decay = target * 0.01 = 100 remaining. Score of 100 needs exactly 123h.
+        const result = coastTime(100, original, warStart)
+        expect(result).toBeCloseTo(warStart + 123 * HOUR, 0)
+    })
+})
+
+describe('nextEnrollmentDeadline', () => {
+    it('returns 12h before next Tuesday noon TCT', () => {
+        // Monday 2026-04-13 at 00:00 UTC (TCT)
+        const monday = Date.UTC(2026, 3, 13, 0, 0, 0) / 1000
+        const deadline = nextEnrollmentDeadline(monday)
+        // Next Tuesday is 2026-04-14 12:00 UTC, minus 12h = 2026-04-14 00:00 UTC
+        const expected = Date.UTC(2026, 3, 14, 0, 0, 0) / 1000
+        expect(deadline).toBe(expected)
+    })
+
+    it('skips to following week if past Tuesday noon', () => {
+        // Tuesday 2026-04-14 at 13:00 UTC (past noon)
+        const pastTuesday = Date.UTC(2026, 3, 14, 13, 0, 0) / 1000
+        const deadline = nextEnrollmentDeadline(pastTuesday)
+        // Next Tuesday is 2026-04-21 12:00 UTC, minus 12h = 2026-04-21 00:00 UTC
+        const expected = Date.UTC(2026, 3, 21, 0, 0, 0) / 1000
+        expect(deadline).toBe(expected)
+    })
+
+    it('returns this Tuesday if before noon on Tuesday', () => {
+        // Tuesday 2026-04-14 at 10:00 UTC (before noon)
+        const earlyTuesday = Date.UTC(2026, 3, 14, 10, 0, 0) / 1000
+        const deadline = nextEnrollmentDeadline(earlyTuesday)
+        // This Tuesday 12:00 UTC minus 12h = 2026-04-14 00:00 UTC
+        const expected = Date.UTC(2026, 3, 14, 0, 0, 0) / 1000
+        expect(deadline).toBe(expected)
+    })
+
+    it('respects custom hoursBeforeEnrollment', () => {
+        const monday = Date.UTC(2026, 3, 13, 0, 0, 0) / 1000
+        const deadline = nextEnrollmentDeadline(monday, 24)
+        // Tuesday 12:00 minus 24h = Monday 12:00
+        const expected = Date.UTC(2026, 3, 13, 12, 0, 0) / 1000
+        expect(deadline).toBe(expected)
+    })
+
+    it('works from a Saturday', () => {
+        const saturday = Date.UTC(2026, 3, 18, 15, 0, 0) / 1000
+        const deadline = nextEnrollmentDeadline(saturday)
+        // Next Tuesday is 2026-04-21 12:00 UTC, minus 12h = 2026-04-21 00:00 UTC
+        const expected = Date.UTC(2026, 3, 21, 0, 0, 0) / 1000
+        expect(deadline).toBe(expected)
+    })
+})

--- a/web/src/wizard_nav.js
+++ b/web/src/wizard_nav.js
@@ -1,15 +1,15 @@
-export function mountWizardFooter() {
+export function mountWizardFooter(steps) {
     const footer = document.createElement('div')
     footer.className = 'fixed bottom-0 left-0 right-0 bg-surface border-t border-border shadow-md px-6 py-3 z-50'
     footer.innerHTML = `
         <div class="max-w-4xl mx-auto flex items-center justify-between">
             <button @click="prevStep()" class="btn-compact bg-muted hover:bg-border disabled:opacity-50">\u2190 Back</button>
             <div class="flex items-center gap-2">
-                <template x-for="n in 3">
+                <template x-for="n in ${steps}">
                     <div :class="{'w-4 h-4 rounded-full': true, 'bg-accent': step === n, 'bg-muted': step !== n}"></div>
                 </template>
             </div>
-            <button @click="nextStep()" :disabled="!canProceed() || step === 3" class="btn-compact bg-accent text-white hover:bg-accentHover disabled:opacity-50">Next \u2192</button>
+            <button @click="nextStep()" :disabled="!canProceed() || step === ${steps}" class="btn-compact bg-accent text-white hover:bg-accentHover disabled:opacity-50">Next \u2192</button>
         </div>`
     document.body.appendChild(footer)
 }

--- a/web/src/wizard_nav.test.js
+++ b/web/src/wizard_nav.test.js
@@ -7,7 +7,7 @@ describe('mountWizardFooter', () => {
     })
 
     it('appends a fixed-position footer to document.body', () => {
-        mountWizardFooter()
+        mountWizardFooter(3)
         const footer = document.body.lastElementChild
         expect(footer).toBeTruthy()
         expect(footer.className).toContain('fixed')
@@ -15,28 +15,36 @@ describe('mountWizardFooter', () => {
     })
 
     it('footer contains a Back button with prevStep directive', () => {
-        mountWizardFooter()
+        mountWizardFooter(3)
         const backBtn = document.body.querySelector('button[\\@click="prevStep()"]')
         expect(backBtn).toBeTruthy()
         expect(backBtn.textContent).toContain('Back')
     })
 
     it('footer contains a Next button with nextStep directive', () => {
-        mountWizardFooter()
+        mountWizardFooter(3)
         const nextBtn = document.body.querySelector('button[\\@click="nextStep()"]')
         expect(nextBtn).toBeTruthy()
         expect(nextBtn.textContent).toContain('Next')
     })
 
     it('footer contains step indicator dots via x-for', () => {
-        mountWizardFooter()
+        mountWizardFooter(3)
         const template = document.body.querySelector('template[x-for="n in 3"]')
         expect(template).toBeTruthy()
     })
 
     it('Next button has disabled binding for step 3', () => {
-        mountWizardFooter()
+        mountWizardFooter(3)
         const nextBtn = document.body.querySelector('button[\\@click="nextStep()"]')
         expect(nextBtn.getAttribute(':disabled')).toBe('!canProceed() || step === 3')
+    })
+
+    it('accepts custom step count', () => {
+        mountWizardFooter(2)
+        const template = document.body.querySelector('template[x-for="n in 2"]')
+        expect(template).toBeTruthy()
+        const nextBtn = document.body.querySelector('button[\\@click="nextStep()"]')
+        expect(nextBtn.getAttribute(':disabled')).toBe('!canProceed() || step === 2')
     })
 })

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
         main: 'index.html',
         rw_matcher: 'rw_matcher.html',
         rw_payroll: 'rw_payroll.html',
+        rw_lead: 'rw_lead.html',
       }
     }
   },


### PR DESCRIPTION
 - Adds a 2-step wizard that calculates whether the faction can stop hitting in a termed ranked war
  - Target score decays 1%/hr of original after 24h (max 123h) — pure formulas in war_score.js with 26
  tests
  - Auto-selects the single active ranked war, defaults deadline to 12h before next Tuesday enrollment
  - Makes mountWizardFooter(steps) accept an explicit step count instead of hardcoding 3